### PR TITLE
Replace HIE instructions with HLS since HIE is now deprecated

### DIFF
--- a/guidance.tex
+++ b/guidance.tex
@@ -176,11 +176,11 @@ See \Cref{sec:editors} for information about text editors that have plugins for 
 	\url{https://github.com/digital-asset/ghcide}
 \end{center}
 
-\subsection{Haskell IDE Engine}
+\subsection{Haskell Language Server}
 
-Haskell IDE Engine (or \texttt{\small hie} for short) is the Haskell community's current effort at creating a unified tool that text editors and IDEs can use to provide Haskell-related functionality. The \texttt{\small hie} program implements Microsoft's Language Server Protocol (LSP) which allows \texttt{\small hie} to be used with any editor that implements LSP. The tool does not currently work on the lab machines, but if you are working on your own machine, you can install it by following the instructions at:
+Haskell Language Server (or \texttt{\small hls} for short) is the Haskell community's current effort at creating a unified tool that text editors and IDEs can use to provide Haskell-related functionality. The \texttt{\small hls} program implements Microsoft's Language Server Protocol (LSP) which allows \texttt{\small hls} to be used with any editor that implements LSP. The tool does not currently work on the lab machines, but if you are working on your own machine, you can install it by following the instructions at:
 \begin{center}\small
-	\url{https://github.com/haskell/haskell-ide-engine}
+	\url{https://github.com/haskell/haskell-language-server}
 \end{center}
 
 \subsection{Editors}

--- a/guidance.tex
+++ b/guidance.tex
@@ -178,7 +178,7 @@ See \Cref{sec:editors} for information about text editors that have plugins for 
 
 \subsection{Haskell Language Server}
 
-Haskell Language Server (or \texttt{\small hls} for short) is the Haskell community's current effort at creating a unified tool that text editors and IDEs can use to provide Haskell-related functionality. The \texttt{\small hls} program implements Microsoft's Language Server Protocol (LSP) which allows \texttt{\small hls} to be used with any editor that implements LSP. The tool does not currently work on the lab machines, but if you are working on your own machine, you can install it by following the instructions at:
+Haskell Language Server (or HLS for short) is the Haskell community's current effort at creating a unified tool that text editors and IDEs can use to provide Haskell-related functionality. The \texttt{\small haskell-language-server} program implements Microsoft's Language Server Protocol (LSP) which allows HLS to be used with any editor that implements LSP. The tool does not currently work on the lab machines, but if you are working on your own machine, you can install it by following the instructions at:
 \begin{center}\small
 	\url{https://github.com/haskell/haskell-language-server}
 \end{center}


### PR DESCRIPTION
[Haskell IDE Engine](https://github.com/haskell/haskell-ide-engine/) is deprecated in favour of [Haskell Language Server](https://github.com/haskell/haskell-language-server) which is the current LSP support for Haskell.