### PR TITLE
Replace 'factors' with 'exponents' to clarify

### DIFF
--- a/labs/lab-list-comprehensions.tex
+++ b/labs/lab-list-comprehensions.tex
@@ -30,7 +30,7 @@ The \haskellIn{n <- [0..10]} part in this example is referred to as a \emph{gene
 
 \taskLine
 
-\task{Using a list comprehension, complete the definition of \haskellIn{powersOfTwo}, which calculates the powers of two for the factors from 1 to 10. The exponentiation operator in Haskell is \haskellIn{^}.} 
+\task{Using a list comprehension, complete the definition of \haskellIn{powersOfTwo}, which calculates the powers of two for the exponents from 1 to 10. The exponentiation operator in Haskell is \haskellIn{^}.} 
 
 \taskLine
 


### PR DESCRIPTION
Change exercise description to match the lab source, clarifying the task