### PR TITLE
Add spacing in Ex 90, 91 and 92

### DIFF
--- a/labs/lab-equational-reasoning.tex
+++ b/labs/lab-equational-reasoning.tex
@@ -31,20 +31,20 @@ Also recall the definition of \haskellIn{add} from \Cref{sec:lecture-10}:
 
 \task[task:succ-comm]{Prove the following property about addition just by rewriting one side of the equation until you end up with the other side:
 	\begin{displaymath}
-	\forall n :: \mathit{Nat} . S~n = \mathit{add}~(S~Z)~n
+	\forall n :: \mathit{Nat} . \quad  S~n = \mathit{add}~(S~Z)~n
 	\end{displaymath}
 	You should show each step of the proof along with a comment to say what you have done at that particular step, as shown in the lecture and the proofs in \Cref{sec:lecture-10}.
 }
 
 \task[task:successor-commutes]{Prove the following property about addition by induction on $n$. For this proof, you will need to make use of some of the other properties you know about $\mathit{add}$, including the one you proved for Exercise \ref{task:succ-comm}.
 	\begin{displaymath}
-	\forall n~m :: \mathit{Nat} . \mathit{add}~(S~n)~m = \mathit{add}~n~(S~m)
+	\forall n~m :: \mathit{Nat} . \quad  \mathit{add}~(S~n)~m = \mathit{add}~n~(S~m)
 	\end{displaymath}
 }
 
 \task[task:add-commutes]{Finally, using all the properties you know about $\mathit{add}$ so far, prove that $\mathit{add}$ commutes:
 	\begin{displaymath}
-	\forall n~m :: \mathit{Nat} . \mathit{add}~n~m = \mathit{add}~m~n
+	\forall n~m :: \mathit{Nat} . \quad  \mathit{add}~n~m = \mathit{add}~m~n
 	\end{displaymath}
 }
 


### PR DESCRIPTION
Added spacing between the quantifier and the equation parts of three exercises in the equational reasoning lab. I found it a little bit confusing before, and this makes them the same format as the other exercises in the section.
*Before:* 
![image](https://user-images.githubusercontent.com/11365435/107663037-d335d180-6c82-11eb-9875-c0782ef64768.png)

*After:* 
![image](https://user-images.githubusercontent.com/11365435/107663116-eb0d5580-6c82-11eb-80bf-ef9109ed9503.png)
